### PR TITLE
Commenting line that wrongly sets the logger level

### DIFF
--- a/custom_components/ide_api/ide_api.py
+++ b/custom_components/ide_api/ide_api.py
@@ -9,7 +9,7 @@ from requests import Session
 
 UTC = tzutc()
 
-logging.getLogger().setLevel(logging.DEBUG)
+# logging.getLogger().setLevel(logging.DEBUG)
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Comment the line that sets the logger level to DEBUG for the whole Home Assistant setup.