### PR TITLE
Entity xx implements device_state_attributes

### DIFF
--- a/custom_components/ide/sensor.py
+++ b/custom_components/ide/sensor.py
@@ -138,7 +138,7 @@ class IDESensor(SensorEntity):
         return self._unit
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes."""
         return self._attributes
 


### PR DESCRIPTION
Error: Entity ide platform implements device_state_attributes

There are upcoming changes in HA 2022.2 that will deprecate the use of device_state_attributes, which needs to be renamed to extra_state_attributes.

Refer to https://developers.home-assistant.io/docs/core/entity/?_highlight=extra_state_attributes#generic-properties 