### PR TITLE
Update README.md to include "Download" step.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Make sure to complement all information to have an "Advanced User" profile.
   ![Custom repository](static/images/add_hacs_custom_repo.png)
   
   - On the "Repository" field put the URL copied before
-  - On the "Catgory" select "Integration"
+  - On the "Category" select "Integration"
+  - Click the "Download" button and download latest version. 
 - Restart HA
 
 ## How to configure


### PR DESCRIPTION
Setup instructions are missing an important, probably obvious to heavy users, step: downloading the actual integration.

Adding the repository without downloading the integration will result in an error when updating your `configuration.yaml` as the `ide` platform will be unknown.